### PR TITLE
Add funding_uri to gemspec template

### DIFF
--- a/gemspec.erb
+++ b/gemspec.erb
@@ -40,6 +40,7 @@ Gem::Specification.new do |spec|
   spec.metadata["changelog_uri"]     = "https://github.com/dry-rb/<%= name %>/blob/main/CHANGELOG.md"
   spec.metadata["source_code_uri"]   = "https://github.com/dry-rb/<%= name %>"
   spec.metadata["bug_tracker_uri"]   = "https://github.com/dry-rb/<%= name %>/issues"
+  spec.metadata["funding_uri"]       = "https://github.com/sponsors/hanami"
 
   spec.required_ruby_version = <%= gemspec.fetch('required_ruby_version', '>= 3.1').inspect %>
 


### PR DESCRIPTION
This PR adds `funding_uri` to the gemspec to help increase visibility using the `bundle fund` command in Bundler.

Follow on from https://github.com/dry-rb/dry-validation/pull/737